### PR TITLE
#27 - Update plugins to work with Java 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -88,17 +88,17 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -108,7 +108,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -132,12 +132,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.4.0</version>
           <dependencies>
             <dependency>
               <!--
@@ -153,22 +153,22 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.15.0</version>
+          <version>3.19.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.7</version>
+          <version>0.8.8</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -178,7 +178,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -188,7 +188,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.13</version>
+          <version>0.15</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -198,12 +198,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>2.2.2</version>
           <dependencies>
             <dependency>
               <groupId>org.asciidoctor</groupId>
@@ -351,7 +351,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.4.1</version>
+            <version>4.7.3.0</version>
             <executions>
               <execution>
                 <phase>package</phase>
@@ -483,9 +483,9 @@
                 - and in projects inheriting from this POM.
               -->
               <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>3.0.9</version>
+                <version>4.0.7</version>
                 <type>pom</type>
               </dependency>
               <dependency>


### PR DESCRIPTION
- groovy 3.0.9 -> 4.0.7
- maven-clean-plugin 3.1.0 -> 3.2.0
- maven-install-plugin 2.5.2 -> 3.1.0
- maven-compiler-plugin 3.8.1 -> 3.10.1
- maven-jar-plugin 3.2.0 -> 3.3.0
- maven-javadoc-plugin 3.3.1 -> 3.4.1
- maven-deploy-plugin 2.8.2 -> 3.0.0
- maven-dependency-plugin 3.1.2 -> 3.4.0
- maven-assembly-plugin 3.3.0 -> 3.4.2
- maven-pmd-plugin 3.15.0 -> 3.19.0
- jacoco-maven-plugin 0.8.7 -> 0.8.8
- maven-antrun-plugin 3.0.0 -> 3.1.0
- maven-enforcer-plugin 3.0.0 -> 3.1.0
- apache-rat-plugin 0.13 -> 0.15
- build-helper-maven-plugin 3.2.0 -> 3.3.0
- asciidoctor-maven-plugin 2.2.1 -> 2.2.2
- spotbugs-maven-plugin 4.4.1 -> 4.7.3.0