### PR TITLE
#32 - Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.15.0</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.2.0</version>
@@ -80,21 +85,22 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.9.1</version>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.11.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -109,17 +115,15 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-eclipse-plugin</artifactId>
-          <version>2.10</version>
+          <version>3.5.0</version>
+          <configuration>
+            <quiet>true</quiet>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0</version>
           <configuration>
             <useReleaseProfile>false</useReleaseProfile>
             <arguments>${arguments} -Pdkpro-release</arguments>
@@ -128,12 +132,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -143,17 +147,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.19.0</version>
+          <version>3.20.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.8</version>
+          <version>0.8.9</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -163,12 +167,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>1.7.0</version>
+          <!-- Stuck with 1.7.0 due to https://issues.apache.org/jira/browse/MRRESOURCES-129 -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -193,12 +198,12 @@
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>2.2.2</version>
+          <version>2.2.3</version>
           <dependencies>
             <dependency>
               <groupId>org.asciidoctor</groupId>
               <artifactId>asciidoctorj-pdf</artifactId>
-              <version>1.6.0</version>
+              <version>2.3.7</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -209,7 +214,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <linkXref>false</linkXref>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>


### PR DESCRIPTION
- versions-maven-plugin -> 2.15.0
- maven-install-plugin 3.1.0 -> 3.1.1
- maven-site-plugin 3.9.1 -> 3.12.1
- maven-compiler-plugin 3.10.1 -> 3.11.0
- maven-resources-plugin 3.3.0 -> 3.3.1
- maven-javadoc-plugin 3.4.1 -> 3.5.0
- maven-release-plugin 3.0.0-M7 -> 3.0.0
- maven-surefire-plugin 3.0.0-M7 -> 3.0.0
- maven-assembly-plugin 3.4.2 -> 3.5.0
- maven-pmd-plugin 3.19.0 -> 3.20.0
- jacoco-maven-plugin 0.8.8 -> 0.8.9
- maven-remote-resources-plugin 3.0.0 -> 1.7.0 (downgrade due to https://issues.apache.org/jira/browse/MRRESOURCES-129)
- maven-enforcer-plugin 3.1.0 -> 3.3.0
- asciidoctor-maven-plugin 2.2.2 -> 2.2.3
- asciidoctorj-pdf 1.6.0 -> 2.3.7