### PR TITLE
#34 - Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,20 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <!-- Also update enforcer below! -->
     <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+    <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+    <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.surefire.heap>512m</maven.surefire.heap>
     <maven.surefire.argLine />
     <jacoco.argLine />
     <gpg.useagent>true</gpg.useagent>
+    <build-groovy-version>4.0.15</build-groovy-version>
+    <build-ant-version>1.10.13</build-ant-version>
+    <build-asciidoctorj-pdf-version>2.3.9</build-asciidoctorj-pdf-version>
   </properties>
   <developers>
     <developer>
@@ -80,7 +87,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -110,12 +117,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
           <configuration>
             <quiet>true</quiet>
           </configuration>
@@ -123,8 +130,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.0.1</version>
           <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
             <useReleaseProfile>false</useReleaseProfile>
             <arguments>${arguments} -Pdkpro-release</arguments>
           </configuration>
@@ -132,7 +140,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -142,17 +150,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.20.0</version>
+          <version>3.21.2</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -173,12 +181,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
@@ -188,7 +196,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -203,9 +211,19 @@
             <dependency>
               <groupId>org.asciidoctor</groupId>
               <artifactId>asciidoctorj-pdf</artifactId>
-              <version>2.3.7</version>
+              <version>${build-asciidoctorj-pdf-version}</version>
             </dependency>
           </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.8.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmaven</groupId>
+          <artifactId>groovy-maven-plugin</artifactId>
+          <version>2.1.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -213,10 +231,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <showDeprecation>true</showDeprecation>
-          <showWarnings>true</showWarnings>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -325,8 +339,7 @@
                   <goal>pmd</goal>
                 </goals>
                 <configuration>
-                  <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                  <targetJdk>${java.maven.compiler.target}</targetJdk>
+                  <targetJdk>${maven.compiler.target}</targetJdk>
                   <linkXRef>false</linkXRef>
                   <excludes>
                     <exclude>**/type/**/*.java</exclude>
@@ -345,12 +358,11 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.7.3.0</version>
             <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>findbugs</goal>
+                  <goal>spotbugs</goal>
                 </goals>
                 <configuration>
                   <spotbugsXmlOutput>true</spotbugsXmlOutput>
@@ -451,7 +463,6 @@
           <plugin>
             <groupId>org.codehaus.gmaven</groupId>
             <artifactId>groovy-maven-plugin</artifactId>
-            <version>2.1.1</version>
             <inherited>true</inherited>
             <executions>
               <execution>
@@ -479,13 +490,13 @@
               <dependency>
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>4.0.11</version>
+                <version>${build-groovy-version}</version>
                 <type>pom</type>
               </dependency>
               <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.13</version>
+                <version>${build-ant-version}</version>
               </dependency>
             </dependencies>
           </plugin>
@@ -545,12 +556,9 @@
       <build>
         <plugins>
           <plugin>
-            <inherited>true</inherited>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <updateReleaseInfo>true</updateReleaseInfo>
-            </configuration>
+            <inherited>true</inherited>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- maven-clean-plugin 3.2.0 -> 3.3.2
- maven-source-plugin 3.2.1 -> 3.3.0
- maven-javadoc-plugin 3.5.0 -> 3.6.2
- maven-release-plugin 3.0.0 -> 3.0.1
- maven-surefire-plugin 3.0.0 -> 3.2.2
- maven-dependency-plugin 3.5.0 -.> 3.6.1
- maven-assembly-plugin 3.5.0 -> 3.6.0
- maven-pmd-plugin 3.20.0 -> 3.21.2
- maven-enforcer-plugin 3.3.0 -> 3.4.1
- maven-gpg-plugin 3.0.1 -> 3.1.0
- maven-war-plugin 3.3.2 -> 3.4.0
- spotbugs-plugin 4.7.3.0 -> 4.8.1.0
- groovy 4.0.11 -> 4.0.15
- ability to override build lib versions using properties
- enable parameter retention in java compiler plugin
- enable auto-versioning of submodules in release plugin