### PR TITLE
#36 - Update dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See the [DKPro Contribution Guidelines](https://dkpro.github.io/contributing). 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Please complete the following information:**
+ - Version and build ID: [see bottom of the browser screen]
+ - OS: [e.g. Windows, Linux, OS X]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: INCEpTION Forum/Mailing list
+    url: https://groups.google.com/d/forum/inception-users
+    about: Community support.
+  - name: INCEpTION Gitter/Matrix Channel
+    url: https://gitter.im/inception-project/Lobby
+    about: Public chat channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,11 @@
+---
+name: Refactoring (for developers)
+about: Refactor the application
+
+---
+
+**Describe the refactoring action**
+A clear and concise description of what the action is.
+
+**Expected benefit**
+A clear and concise description of what you expect to improve by the refactoring.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**What's in the PR**
+* ...
+
+**How to test manually**
+* ...
+
+**Automatic testing**
+* [ ] PR includes unit tests
+
+**Documentation**
+* [ ] PR updates documentation

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Also update enforcer below! -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
     <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -82,7 +82,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.15.0</version>
+          <version>2.16.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -92,7 +92,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -102,7 +102,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -112,17 +112,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.2</version>
+          <version>3.6.3</version>
           <configuration>
             <quiet>true</quiet>
           </configuration>
@@ -140,12 +140,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.2.5</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -155,17 +155,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.21.2</version>
+          <version>3.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.9</version>
+          <version>0.8.12</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -175,7 +175,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>1.7.0</version>
+          <version>3.2.0</version>
           <!-- Stuck with 1.7.0 due to https://issues.apache.org/jira/browse/MRRESOURCES-129 -->
         </plugin>
         <plugin>
@@ -186,12 +186,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.15</version>
+          <version>0.16.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -201,12 +201,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>2.2.3</version>
+          <version>3.0.0</version>
           <dependencies>
             <dependency>
               <groupId>org.asciidoctor</groupId>
@@ -218,7 +218,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.8.1.0</version>
+          <version>4.8.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>
@@ -262,7 +262,7 @@
                   <message>Minimum  Maven 3.3.2 required as activation policy for profiles with multiple activation conditions changed from OR to AND.</message>
                 </requireMavenVersion>
                 <requireMavenVersion>
-                  <version>[3.5,)</version>
+                  <version>[3.8.5,)</version>
                   <message>Minimum Maven version 3.5 required for plugins.</message>
                 </requireMavenVersion>
               </rules>
@@ -515,7 +515,7 @@
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
                   <resourceBundles>
-                    <resourceBundle>de.tudarmstadt.ukp.dkpro.core:build-resources:2</resourceBundle>
+                    <resourceBundle>de.tudarmstadt.ukp.dkpro.core:build-resources:3</resourceBundle>
                   </resourceBundles>
                 </configuration>
               </execution>


### PR DESCRIPTION
- Java 11 -> 17
- versions-maven-plugin 2.15.0 -> 2.16.2
- maven-install-plugin 3.1.1 -> 3.1.2
- maven-compiler-plugin 3.11.0 -> 3.13.0
- maven-jar-plugin 3.3.0 -> 3.4.1
- maven-source-plugin 3.3.0 -> 3.3.1
- maven-javadoc-plugin 3.6.2 -> 3.6.3
- maven-surefire-plugin 3.2.2 -> 3.2.5
- maven-deploy-plugin 3.1.1 -> 3.1.2
- maven-assembly-plugin 3.6.0 -> 3.7.1
- maven-pmd-plugin 3.21.2 -> 3.22.0
- jacoco-maven-plugin 0.8.9 -> 0.8.12
- maven-remote-resources-plugin 1.7.0 -> 3.2.0
- maven-gpg-plugin 3.1.0 -> 3.2.4
- apache-rat-plugin 0.15 -> 0.16.1
- build-helper-maven-plugin 3.3.0 -> 3.5.0
- asciidoctor-maven-plugin 2.2.3 -> 3.0.0
- spotbugs-maven-plugin 4.8.1.0 -> 4.8.5.0
- build-resources 2 -> 3