### PR TITLE
Issue #39: Upgrade plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <maven.surefire.argLine />
     <jacoco.argLine />
     <gpg.useagent>true</gpg.useagent>
-    <build-groovy-version>4.0.15</build-groovy-version>
-    <build-ant-version>1.10.13</build-ant-version>
-    <build-asciidoctorj-pdf-version>2.3.9</build-asciidoctorj-pdf-version>
+    <build-groovy-version>4.0.21</build-groovy-version>
+    <build-ant-version>1.10.14</build-ant-version>
+    <build-asciidoctorj-pdf-version>2.3.15</build-asciidoctorj-pdf-version>
   </properties>
   <developers>
     <developer>
@@ -72,17 +72,17 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.16.2</version>
+          <version>2.18.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -92,7 +92,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -102,7 +102,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -112,7 +112,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.11.2</version>
           <configuration>
             <quiet>true</quiet>
           </configuration>
@@ -120,7 +120,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <useReleaseProfile>false</useReleaseProfile>
@@ -130,17 +130,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -150,12 +150,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.22.0</version>
+          <version>3.27.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
+          <version>0.8.13</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -165,18 +165,18 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <!-- Stuck with 1.7.0 due to https://issues.apache.org/jira/browse/MRRESOURCES-129 -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.2.4</version>
+          <version>3.2.8</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
@@ -191,12 +191,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.0</version>
           <dependencies>
             <dependency>
               <groupId>org.asciidoctor</groupId>
@@ -208,7 +208,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.8.5.0</version>
+          <version>4.9.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>
@@ -257,8 +257,8 @@
                   <message>Minimum  Maven 3.3.2 required as activation policy for profiles with multiple activation conditions changed from OR to AND.</message>
                 </requireMavenVersion>
                 <requireMavenVersion>
-                  <version>[3.8.5,)</version>
-                  <message>Minimum Maven version 3.5 required for plugins.</message>
+                  <version>[3.8.8,)</version>
+                  <message>Minimum Maven version 3.8.8 required for plugins.</message>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
**What's in the PR**
* build-groovy-version 4.0.15 -> 4.0.21
* build-ant-version 1.10.13 -> 1.10.14
* build-asciidoctorj-pdf-version 2.3.9 -> 2.3.15
* versions-maven-plugin 2.16.2 -> 2.18.0
* maven-clean-plugin 3.3.2 -> 3.5.0
* maven-install-plugin 3.1.2 -> 3.1.4
* maven-compiler-plugin 3.13.0 -> 3.14.0
* maven-jar-plugin 3.4.1 -> 3.4.2
* maven-javadoc-plugin 3.6.3 -> 3.11.2
* maven-release-plugin 3.0.1 -> 3.1.1
* maven-surefire-plugin 3.2.5 -> 3.5.3
* maven-deploy-plugin 3.1.2 -> 3.1.4
* maven-dependency-plugin 3.6.1 -> 3.8.1
* maven-pmd-plugin 3.22.0 -> 3.27.0
* jacoco-maven-plugin 0.8.12 -> 0.8.13
* maven-remote-resources-plugin 3.2.0 -> 3.3.0
* maven-enforcer-plugin 3.4.1 -> 3.6.0
* maven-gpg-plugin 3.2.4 -> 3.2.8
* build-helper-maven-plugin 3.5.0 -> 3.6.1
* asciidoctor-maven-plugin 3.0.0 -> 3.2.0
* spotbugs-maven-plugin 4.8.5.0 -> 4.9.3.2

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
