### PR TITLE
#47 - Include license and notice files in source and test JARs, not only in the binary JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
                 </goals>
                 <phase>generate-resources</phase>
                 <configuration>
-                  <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+                  <outputDirectory>${project.build.directory}/license-resources/META-INF</outputDirectory>
                   <resources>
                     <resource>
                       <filtering>false</filtering>
@@ -547,6 +547,28 @@
                         <include>README.txt</include>
                         <include>LICENSE.txt</include>
                       </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <inherited>true</inherited>
+            <executions>
+              <execution>
+                <id>add-license-resources</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>add-resource</goal>
+                  <goal>add-test-resource</goal>
+                </goals>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}/license-resources</directory>
                     </resource>
                   </resources>
                 </configuration>


### PR DESCRIPTION
**What's in the PR**
- Register license and readme files as a dedicated Maven resource root to include them in source and test JARs alongside the binary JAR
- Use build-helper-maven-plugin to register the license-resources directory for both main and test resource inclusion

**How to test manually**
* Check if the NOTICE, LICENSE, README and DEPENDENCIES files are in the binary (test) JARs s well as in the source (test) JARs

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
