### PR TITLE
#51 - Keep the copyright year in the NOTICE file up to date automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,35 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <!--
+          - Integration tests for the build logic in this POM. The consumer projects under
+          - src/it inherit from the POM being built and are checked against the NOTICE.txt
+          - they end up generating.
+        -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <projectsDirectory>src/it</projectsDirectory>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <postBuildHookScript>verify</postBuildHookScript>
+          <streamLogs>false</streamLogs>
+          <showErrors>true</showErrors>
+          <goals>
+            <goal>process-resources</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
@@ -486,6 +515,55 @@
                   </source>
                 </configuration>
               </execution>
+              <execution>
+                <!-- Determine the copyright end year rendered into NOTICE.txt -->
+                <id>copyright-year</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <source>
+                    import java.time.Instant
+                    import java.time.Year
+                    import java.time.ZoneOffset
+
+                    // A pinned project.build.outputTimestamp means the project builds
+                    // reproducibly, so the year has to come from that timestamp - otherwise
+                    // rebuilding an old commit later would silently change its NOTICE.
+                    // Without a pin there is nothing to be reproducible against and the
+                    // current year is what the notice should state. Hard-coding a year is
+                    // avoided on purpose - it goes stale without anything failing.
+                    //
+                    // -D sets a user property, which does not show up in project.properties,
+                    // so the session has to be consulted first.
+                    def ts = session.userProperties['project.build.outputTimestamp'] ?:
+                             project.properties['project.build.outputTimestamp']
+
+                    def currentYear = { Year.now(ZoneOffset.UTC).value as String }
+
+                    def year
+                    if (!ts) {
+                      // Property entirely absent
+                      year = currentYear()
+                    }
+                    else if (ts ==~ /^\d+$/) {
+                      // Epoch seconds, as used by SOURCE_DATE_EPOCH
+                      year = Instant.ofEpochSecond(ts as long).atZone(ZoneOffset.UTC).year as String
+                    }
+                    else if (ts ==~ /^\d{4}-\d{2}-\d{2}T.*/ &amp;&amp; !ts.startsWith('1980-')) {
+                      // ISO 8601. Maven substitutes the 1980 epoch sentinel when the property
+                      // is not set anywhere, which must not be mistaken for a deliberate pin.
+                      year = ts.substring(0, 4)
+                    }
+                    else {
+                      year = currentYear()
+                    }
+
+                    project.properties['dkpro.copyright.year'] = year
+                  </source>
+                </configuration>
+              </execution>
             </executions>
             <dependencies>
               <!--
@@ -520,7 +598,7 @@
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
                   <resourceBundles>
-                    <resourceBundle>de.tudarmstadt.ukp.dkpro.core:build-resources:3</resourceBundle>
+                    <resourceBundle>de.tudarmstadt.ukp.dkpro.core:build-resources:4</resourceBundle>
                   </resourceBundles>
                 </configuration>
               </execution>

--- a/src/it/timestamp-1980-sentinel/LICENSE.txt
+++ b/src/it/timestamp-1980-sentinel/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license placeholder - presence activates the add-license profile.

--- a/src/it/timestamp-1980-sentinel/pom.xml
+++ b/src/it/timestamp-1980-sentinel/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <groupId>org.dkpro.it</groupId>
+  <artifactId>timestamp-1980-sentinel</artifactId>
+  <version>1.0</version>
+
+  <name>Timestamp 1980 Sentinel</name>
+  <inceptionYear>2007</inceptionYear>
+  <organization>
+    <name>Test Organization</name>
+  </organization>
+
+  <properties>
+    <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
+  </properties>
+</project>

--- a/src/it/timestamp-1980-sentinel/verify.groovy
+++ b/src/it/timestamp-1980-sentinel/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The 1980 epoch sentinel is what Maven substitutes when nothing is pinned, so it is
+// treated as 'unpinned' and the current year is used.
+def notice = new File(basedir, 'target/maven-shared-archive-resources/META-INF/NOTICE.txt')
+assert notice.exists() : "NOTICE.txt was not generated"
+
+def text = notice.text
+
+assert !text.contains('${') : "Unresolved reference in NOTICE.txt:\n${text}"
+
+def expected = java.time.Year.now(java.time.ZoneOffset.UTC).value
+assert text.contains("Copyright 2007-${expected} Test Organization") : \
+    "Expected 'Copyright 2007-${expected} Test Organization' but got:\n${text}"

--- a/src/it/timestamp-epoch-seconds/LICENSE.txt
+++ b/src/it/timestamp-epoch-seconds/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license placeholder - presence activates the add-license profile.

--- a/src/it/timestamp-epoch-seconds/pom.xml
+++ b/src/it/timestamp-epoch-seconds/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <groupId>org.dkpro.it</groupId>
+  <artifactId>timestamp-epoch-seconds</artifactId>
+  <version>1.0</version>
+
+  <name>Timestamp Epoch Seconds</name>
+  <inceptionYear>2007</inceptionYear>
+  <organization>
+    <name>Test Organization</name>
+  </organization>
+
+  <properties>
+    <project.build.outputTimestamp>1000000000</project.build.outputTimestamp>
+  </properties>
+</project>

--- a/src/it/timestamp-epoch-seconds/verify.groovy
+++ b/src/it/timestamp-epoch-seconds/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Epoch seconds are a legal project.build.outputTimestamp and yield their own year.
+def notice = new File(basedir, 'target/maven-shared-archive-resources/META-INF/NOTICE.txt')
+assert notice.exists() : "NOTICE.txt was not generated"
+
+def text = notice.text
+
+assert !text.contains('${') : "Unresolved reference in NOTICE.txt:\n${text}"
+
+assert text.contains('Copyright 2007-2001 Test Organization') : \
+    "Expected 'Copyright 2007-2001 Test Organization' but got:\n${text}"

--- a/src/it/timestamp-pinned-in-pom/LICENSE.txt
+++ b/src/it/timestamp-pinned-in-pom/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license placeholder - presence activates the add-license profile.

--- a/src/it/timestamp-pinned-in-pom/pom.xml
+++ b/src/it/timestamp-pinned-in-pom/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <groupId>org.dkpro.it</groupId>
+  <artifactId>timestamp-pinned-in-pom</artifactId>
+  <version>1.0</version>
+
+  <name>Timestamp Pinned In POM</name>
+  <inceptionYear>2007</inceptionYear>
+  <organization>
+    <name>Test Organization</name>
+  </organization>
+
+  <properties>
+    <project.build.outputTimestamp>2019-03-14T10:00:00Z</project.build.outputTimestamp>
+  </properties>
+</project>

--- a/src/it/timestamp-pinned-in-pom/verify.groovy
+++ b/src/it/timestamp-pinned-in-pom/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pinned in <properties> -> the pinned year wins over the build clock.
+def notice = new File(basedir, 'target/maven-shared-archive-resources/META-INF/NOTICE.txt')
+assert notice.exists() : "NOTICE.txt was not generated"
+
+def text = notice.text
+
+assert !text.contains('${') : "Unresolved reference in NOTICE.txt:\n${text}"
+
+assert text.contains('Copyright 2007-2019 Test Organization') : \
+    "Expected 'Copyright 2007-2019 Test Organization' but got:\n${text}"

--- a/src/it/timestamp-pinned-on-cli/LICENSE.txt
+++ b/src/it/timestamp-pinned-on-cli/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license placeholder - presence activates the add-license profile.

--- a/src/it/timestamp-pinned-on-cli/invoker.properties
+++ b/src/it/timestamp-pinned-on-cli/invoker.properties
@@ -1,0 +1,4 @@
+# Pin the timestamp the way a release build would: as a user property on the command line.
+# This is deliberately not set in the POM - a user property does not appear in
+# project.properties and has to be picked up from the session instead.
+invoker.goals = process-resources -Dproject.build.outputTimestamp=2018-05-06T07:08:09Z

--- a/src/it/timestamp-pinned-on-cli/pom.xml
+++ b/src/it/timestamp-pinned-on-cli/pom.xml
@@ -1,0 +1,36 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <groupId>org.dkpro.it</groupId>
+  <artifactId>timestamp-pinned-on-cli</artifactId>
+  <version>1.0</version>
+
+  <name>Timestamp Pinned On CLI</name>
+  <inceptionYear>2007</inceptionYear>
+  <organization>
+    <name>Test Organization</name>
+  </organization>
+</project>

--- a/src/it/timestamp-pinned-on-cli/verify.groovy
+++ b/src/it/timestamp-pinned-on-cli/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pinned as a user property -> the pinned year wins over the build clock.
+def notice = new File(basedir, 'target/maven-shared-archive-resources/META-INF/NOTICE.txt')
+assert notice.exists() : "NOTICE.txt was not generated"
+
+def text = notice.text
+
+assert !text.contains('${') : "Unresolved reference in NOTICE.txt:\n${text}"
+
+assert text.contains('Copyright 2007-2018 Test Organization') : \
+    "Expected 'Copyright 2007-2018 Test Organization' but got:\n${text}"

--- a/src/it/timestamp-unset/LICENSE.txt
+++ b/src/it/timestamp-unset/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license placeholder - presence activates the add-license profile.

--- a/src/it/timestamp-unset/pom.xml
+++ b/src/it/timestamp-unset/pom.xml
@@ -1,0 +1,36 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>@project.artifactId@</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <groupId>org.dkpro.it</groupId>
+  <artifactId>timestamp-unset</artifactId>
+  <version>1.0</version>
+
+  <name>Timestamp Unset</name>
+  <inceptionYear>2007</inceptionYear>
+  <organization>
+    <name>Test Organization</name>
+  </organization>
+</project>

--- a/src/it/timestamp-unset/verify.groovy
+++ b/src/it/timestamp-unset/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Nothing pinned -> the notice states the current year.
+def notice = new File(basedir, 'target/maven-shared-archive-resources/META-INF/NOTICE.txt')
+assert notice.exists() : "NOTICE.txt was not generated"
+
+def text = notice.text
+
+assert !text.contains('${') : "Unresolved reference in NOTICE.txt:\n${text}"
+
+def expected = java.time.Year.now(java.time.ZoneOffset.UTC).value
+assert text.contains("Copyright 2007-${expected} Test Organization") : \
+    "Expected 'Copyright 2007-${expected} Test Organization' but got:\n${text}"


### PR DESCRIPTION
**What's in the PR**
- Automate copyright year calculation in the NOTICE.txt file based on build timestamp
- build-resources 3 -> 4
- Add integration tests for copyright year resolution across multiple timestamp scenarios
- Add maven-invoker-plugin to run integration tests during the build

**How to test manually**
* Check if the NOTICE files now get the proper ranges

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
